### PR TITLE
all: use context.Canceled (instead of io.EOF) to detect when work can…

### DIFF
--- a/cmd/tdaq-datasrc/main.go
+++ b/cmd/tdaq-datasrc/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"io"
 	"math/rand"
 	"os"
 	"time"
@@ -91,7 +90,7 @@ func (dev *datasrc) adc(ctx tdaq.Context, dst *tdaq.Frame) error {
 	select {
 	case <-ctx.Ctx.Done():
 		dst.Body = nil
-		return io.EOF
+		return nil
 	case data := <-dev.data:
 		dst.Body = data
 	}

--- a/cmd/tdaq-i64-gen/main.go
+++ b/cmd/tdaq-i64-gen/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"context"
 	"encoding/binary"
-	"io"
 	"os"
 	"time"
 
@@ -74,7 +73,7 @@ func (dev *counter) adc(ctx tdaq.Context, dst *tdaq.Frame) error {
 	select {
 	case <-ctx.Ctx.Done():
 		dst.Body = nil
-		return io.EOF
+		return nil
 	case data := <-dev.ch:
 		dst.Body = make([]byte, 8)
 		binary.LittleEndian.PutUint64(dst.Body, uint64(data))

--- a/iomgr.go
+++ b/iomgr.go
@@ -6,6 +6,7 @@ package tdaq // import "github.com/go-daq/tdaq"
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net"
 	"sort"
@@ -322,9 +323,10 @@ func (mgr *omgr) run(ctx Context, ep string, op *oport, f OutputHandler) {
 			resp := Frame{Type: FrameData, Path: ep}
 			err := f(ctx, &resp)
 			if err != nil {
-				if err != io.EOF {
-					ctx.Msg.Errorf("could not process data frame for %q: %+v", ep, err)
-				}
+				ctx.Msg.Errorf("could not process data frame for %q: %+v", ep, err)
+				continue
+			}
+			if err := ctx.Ctx.Err(); err != nil && xerrors.Is(err, context.Canceled) {
 				continue
 			}
 

--- a/tdaq_test.go
+++ b/tdaq_test.go
@@ -7,7 +7,6 @@ package tdaq // import "github.com/go-daq/tdaq"
 import (
 	"bytes"
 	"context"
-	"io"
 	"math/rand"
 	"net"
 	"reflect"
@@ -81,7 +80,7 @@ func (dev *TestProducer) ADC(ctx Context, dst *Frame) error {
 	select {
 	case <-ctx.Ctx.Done():
 		dst.Body = nil
-		return io.EOF
+		return nil
 	case data := <-dev.data:
 		dst.Body = data
 	}


### PR DESCRIPTION
… be interupted