### PR TITLE
xdaq: add time-of-flight benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ go_import_path: github.com/go-daq/tdaq
 
 go:
  - 1.13.x
- - 1.12.x
 
 os:
  - linux

--- a/log/log.go
+++ b/log/log.go
@@ -56,12 +56,12 @@ func (lvl Level) String() string {
 
 // MsgStream provides access to verbosity-defined formated messages, a la fmt.Printf.
 type MsgStream interface {
-	Debugf(format string, a ...interface{}) (int, error)
-	Infof(format string, a ...interface{}) (int, error)
-	Warnf(format string, a ...interface{}) (int, error)
-	Errorf(format string, a ...interface{}) (int, error)
+	Debugf(format string, a ...interface{})
+	Infof(format string, a ...interface{})
+	Warnf(format string, a ...interface{})
+	Errorf(format string, a ...interface{})
 
-	Msg(lvl Level, format string, a ...interface{}) (int, error)
+	Msg(lvl Level, format string, a ...interface{})
 }
 
 type msgstream struct {
@@ -75,34 +75,33 @@ var (
 )
 
 // Debugf displays a (formated) DBG message
-func Debugf(format string, a ...interface{}) (int, error) {
-	return Default.Debugf(format, a...)
+func Debugf(format string, a ...interface{}) {
+	Default.Debugf(format, a...)
 }
 
 // Infof displays a (formated) INFO message
-func Infof(format string, a ...interface{}) (int, error) {
-	return Default.Infof(format, a...)
+func Infof(format string, a ...interface{}) {
+	Default.Infof(format, a...)
 }
 
 // Warnf displays a (formated) WARN message
-func Warnf(format string, a ...interface{}) (int, error) {
-	return Default.Warnf(format, a...)
+func Warnf(format string, a ...interface{}) {
+	Default.Warnf(format, a...)
 }
 
 // Errorf displays a (formated) ERR message
-func Errorf(format string, a ...interface{}) (int, error) {
-	return Default.Errorf(format, a...)
+func Errorf(format string, a ...interface{}) {
+	Default.Errorf(format, a...)
 }
 
 // Fatalf displays a (formated) ERR message and stops the program.
-func Fatalf(format string, a ...interface{}) (int, error) {
+func Fatalf(format string, a ...interface{}) {
 	Default.Errorf(format, a...)
 	os.Exit(1)
-	panic("not reachable")
 }
 
 // Panicf displays a (formated) ERR message and panics.
-func Panicf(format string, a ...interface{}) (int, error) {
+func Panicf(format string, a ...interface{}) {
 	Default.Errorf(format, a...)
 	panic("tdaq panic")
 }
@@ -127,36 +126,36 @@ func newMsgStream(name string, lvl Level, w io.Writer) msgstream {
 }
 
 // Debugf displays a (formated) DBG message
-func (msg msgstream) Debugf(format string, a ...interface{}) (int, error) {
-	return msg.Msg(LvlDebug, format, a...)
+func (msg msgstream) Debugf(format string, a ...interface{}) {
+	msg.Msg(LvlDebug, format, a...)
 }
 
 // Infof displays a (formated) INFO message
-func (msg msgstream) Infof(format string, a ...interface{}) (int, error) {
-	return msg.Msg(LvlInfo, format, a...)
+func (msg msgstream) Infof(format string, a ...interface{}) {
+	msg.Msg(LvlInfo, format, a...)
 }
 
 // Warnf displays a (formated) WARN message
-func (msg msgstream) Warnf(format string, a ...interface{}) (int, error) {
-	return msg.Msg(LvlWarning, format, a...)
+func (msg msgstream) Warnf(format string, a ...interface{}) {
+	msg.Msg(LvlWarning, format, a...)
 }
 
 // Errorf displays a (formated) ERR message
-func (msg msgstream) Errorf(format string, a ...interface{}) (int, error) {
-	return msg.Msg(LvlError, format, a...)
+func (msg msgstream) Errorf(format string, a ...interface{}) {
+	msg.Msg(LvlError, format, a...)
 }
 
 // Msg displays a (formated) message with level lvl.
-func (msg msgstream) Msg(lvl Level, format string, a ...interface{}) (int, error) {
+func (msg msgstream) Msg(lvl Level, format string, a ...interface{}) {
 	if lvl < msg.lvl {
-		return 0, nil
+		return
 	}
 	eol := ""
 	if !strings.HasSuffix(format, "\n") {
 		eol = "\n"
 	}
 	format = msg.n + lvl.MsgString() + " " + format + eol
-	return fmt.Fprintf(msg.w, format, a...)
+	fmt.Fprintf(msg.w, format, a...)
 }
 
 var (

--- a/server.go
+++ b/server.go
@@ -651,32 +651,32 @@ func newMsgStream(name string, lvl log.Level, w io.Writer) *msgstream {
 }
 
 // Debugf displays a (formated) DBG message
-func (msg *msgstream) Debugf(format string, a ...interface{}) (int, error) {
-	return msg.Msg(log.LvlDebug, format, a...)
+func (msg *msgstream) Debugf(format string, a ...interface{}) {
+	msg.Msg(log.LvlDebug, format, a...)
 }
 
 // Infof displays a (formated) INFO message
-func (msg *msgstream) Infof(format string, a ...interface{}) (int, error) {
-	return msg.Msg(log.LvlInfo, format, a...)
+func (msg *msgstream) Infof(format string, a ...interface{}) {
+	msg.Msg(log.LvlInfo, format, a...)
 }
 
 // Warnf displays a (formated) WARN message
-func (msg *msgstream) Warnf(format string, a ...interface{}) (int, error) {
-	return msg.Msg(log.LvlWarning, format, a...)
+func (msg *msgstream) Warnf(format string, a ...interface{}) {
+	msg.Msg(log.LvlWarning, format, a...)
 }
 
 // Errorf displays a (formated) ERR message
-func (msg *msgstream) Errorf(format string, a ...interface{}) (int, error) {
-	return msg.Msg(log.LvlError, format, a...)
+func (msg *msgstream) Errorf(format string, a ...interface{}) {
+	msg.Msg(log.LvlError, format, a...)
 }
 
 // Msg displays a (formated) message with level lvl.
-func (msg *msgstream) Msg(lvl log.Level, format string, a ...interface{}) (int, error) {
+func (msg *msgstream) Msg(lvl log.Level, format string, a ...interface{}) {
 	msg.mu.Lock()
 	defer msg.mu.Unlock()
 
 	if lvl < msg.lvl {
-		return 0, nil
+		return
 	}
 	eol := ""
 	if !strings.HasSuffix(format, "\n") {
@@ -693,7 +693,7 @@ func (msg *msgstream) Msg(lvl log.Level, format string, a ...interface{}) (int, 
 		})
 	}
 
-	return msg.w.Write(str)
+	_, _ = msg.w.Write(str)
 }
 
 func (msg *msgstream) setLog(conn net.Conn) {

--- a/xdaq/i64genUTC.go
+++ b/xdaq/i64genUTC.go
@@ -1,0 +1,90 @@
+// Copyright 2019 The go-daq Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xdaq // import "github.com/go-daq/tdaq/xdaq"
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/go-daq/tdaq"
+)
+
+// I64GenUTC publishes int64 data (time.Now in UTC) on an output end-point.
+type I64GenUTC struct {
+	N    int64         // number of values generated since /init.
+	Freq time.Duration // frequency of the int64 data sequence generation.
+
+	ch chan int64
+}
+
+func (dev *I64GenUTC) OnConfig(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /config command...")
+	return nil
+}
+
+func (dev *I64GenUTC) OnInit(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /init command...")
+	dev.N = 0
+	dev.ch = make(chan int64)
+	if dev.Freq <= 0 {
+		dev.Freq = 10 * time.Millisecond
+	}
+	return nil
+}
+
+func (dev *I64GenUTC) OnReset(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /init command...")
+	dev.N = 0
+	dev.ch = make(chan int64)
+	return nil
+}
+
+func (dev *I64GenUTC) OnStart(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /start command...")
+	return nil
+}
+
+func (dev *I64GenUTC) OnStop(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	n := dev.N - 1
+	ctx.Msg.Infof("received /stop command... -> n=%d", n)
+	return nil
+}
+
+func (dev *I64GenUTC) OnQuit(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /quit command...")
+	return nil
+}
+
+func (dev *I64GenUTC) Output(ctx tdaq.Context, dst *tdaq.Frame) error {
+	select {
+	case <-ctx.Ctx.Done():
+		dst.Body = nil
+		return nil
+	case data := <-dev.ch:
+		dst.Body = make([]byte, 8)
+		binary.LittleEndian.PutUint64(dst.Body, uint64(data))
+	}
+	return nil
+}
+
+func (dev *I64GenUTC) Loop(ctx tdaq.Context) error {
+	for {
+		select {
+		case <-ctx.Ctx.Done():
+			return nil
+		default:
+			select {
+			case dev.ch <- dev.now():
+				dev.N++
+			default:
+			}
+		}
+		time.Sleep(dev.Freq)
+	}
+}
+
+func (dev *I64GenUTC) now() int64 {
+	return time.Now().UTC().UnixNano()
+}

--- a/xdaq/i64tof.go
+++ b/xdaq/i64tof.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The go-daq Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xdaq // import "github.com/go-daq/tdaq/xdaq"
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/go-daq/tdaq"
+	"gonum.org/v1/gonum/stat"
+)
+
+// I64TOF computes the time-of-flight of an int64 token from an input end-point.
+type I64TOF struct {
+	vals   []float64
+	N      int64   // counter of values seen since /init
+	Mean   float64 // mean of time-of-flight
+	StdDev float64 // stddev of time-of-flight
+}
+
+func (dev *I64TOF) OnConfig(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /config command...")
+	return nil
+}
+
+func (dev *I64TOF) OnInit(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /init command...")
+	dev.N = +0
+	dev.vals = nil
+	dev.Mean = 0
+	dev.StdDev = 0
+	return nil
+}
+
+func (dev *I64TOF) OnReset(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /reset command...")
+	dev.vals = nil
+	dev.N = +0
+	dev.Mean = 0
+	dev.StdDev = 0
+	return nil
+}
+
+func (dev *I64TOF) OnStart(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /start command...")
+	return nil
+}
+
+func (dev *I64TOF) OnStop(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	n := dev.N
+	dev.Mean, dev.StdDev = stat.MeanStdDev(dev.vals, nil)
+	ctx.Msg.Infof("received /stop command... -> n=%d (mean=%v, std=%v)", n, dev.Mean, dev.StdDev)
+	return nil
+}
+
+func (dev *I64TOF) OnQuit(ctx tdaq.Context, resp *tdaq.Frame, req tdaq.Frame) error {
+	ctx.Msg.Debugf("received /quit command...")
+	return nil
+}
+
+func (dev *I64TOF) Input(ctx tdaq.Context, src tdaq.Frame) error {
+	var (
+		now = time.Now().UTC().UnixNano()
+		v   = int64(binary.LittleEndian.Uint64(src.Body))
+	)
+
+	dev.N++
+	dev.vals = append(dev.vals, float64(now-v))
+	ctx.Msg.Debugf("received: %d -> %d", v, dev.N)
+	return nil
+}


### PR DESCRIPTION
Fixes go-daq/tdaq#47.

```
    $> go test -run=NONE -bench=. -benchmem -v -count=30 ./xdaq |& tee ref.txt
    goos: linux
    goarch: amd64
    pkg: github.com/go-daq/tdaq/xdaq
    BenchmarkSequence
    BenchmarkSequence-8            1        5000764047 ns/op             39133 bench-01-tokens/op/s      17134 bench-02-tof-ns           34194 bench-03-stddev-ns   101745048 B/op   3328323 allocs/op
    BenchmarkSequence-8            1        5000789169 ns/op             39186 bench-01-tokens/op/s      17694 bench-02-tof-ns           41476 bench-03-stddev-ns   101698024 B/op   3332134 allocs/op
    BenchmarkSequence-8            1        5000773512 ns/op             40041 bench-01-tokens/op/s      18508 bench-02-tof-ns           52643 bench-03-stddev-ns   103741416 B/op   3405096 allocs/op
    BenchmarkSequence-8            1        5000941123 ns/op             39333 bench-01-tokens/op/s      16999 bench-02-tof-ns           33107 bench-03-stddev-ns   102050552 B/op   3344617 allocs/op
    BenchmarkSequence-8            1        5000948268 ns/op             39681 bench-01-tokens/op/s      17498 bench-02-tof-ns           41461 bench-03-stddev-ns   102854264 B/op   3373999 allocs/op
    BenchmarkSequence-8            1        5000802382 ns/op             40411 bench-01-tokens/op/s     218253 bench-02-tof-ns         2101211 bench-03-stddev-ns   104604312 B/op   3436343 allocs/op
    BenchmarkSequence-8            1        5000991771 ns/op             38856 bench-01-tokens/op/s      18902 bench-02-tof-ns           53056 bench-03-stddev-ns   100924152 B/op   3304129 allocs/op
    BenchmarkSequence-8            1        5001045034 ns/op             38862 bench-01-tokens/op/s      29972 bench-02-tof-ns          272517 bench-03-stddev-ns   100932120 B/op   3304553 allocs/op
    BenchmarkSequence-8            1        5000728386 ns/op             38456 bench-01-tokens/op/s      16113 bench-02-tof-ns           11971 bench-03-stddev-ns   99976872 B/op    3270004 allocs/op
    BenchmarkSequence-8            1        5000796545 ns/op             39644 bench-01-tokens/op/s      18507 bench-02-tof-ns           48252 bench-03-stddev-ns   102789848 B/op   3370969 allocs/op
    BenchmarkSequence-8            1        5000784386 ns/op             39161 bench-01-tokens/op/s      17904 bench-02-tof-ns          148515 bench-03-stddev-ns   101668232 B/op   3330001 allocs/op
    BenchmarkSequence-8            1        5000772017 ns/op             38305 bench-01-tokens/op/s      19196 bench-02-tof-ns           55586 bench-03-stddev-ns   99640584 B/op    3257356 allocs/op
    BenchmarkSequence-8            1        5000774392 ns/op             37453 bench-01-tokens/op/s      24713 bench-02-tof-ns          218928 bench-03-stddev-ns   95724232 B/op    3184883 allocs/op
    BenchmarkSequence-8            1        5000743822 ns/op             39402 bench-01-tokens/op/s      18735 bench-02-tof-ns           54339 bench-03-stddev-ns   102225128 B/op   3350612 allocs/op
    BenchmarkSequence-8            1        5000778143 ns/op             38215 bench-01-tokens/op/s      16658 bench-02-tof-ns           25174 bench-03-stddev-ns   99412536 B/op    3249591 allocs/op
    BenchmarkSequence-8            1        5000851216 ns/op             38720 bench-01-tokens/op/s      18232 bench-02-tof-ns           47046 bench-03-stddev-ns   100617560 B/op   3292671 allocs/op
    BenchmarkSequence-8            1        5000774201 ns/op             40836 bench-01-tokens/op/s      16533 bench-02-tof-ns           25573 bench-03-stddev-ns   105586904 B/op   3472392 allocs/op
    BenchmarkSequence-8            1        5000743567 ns/op             39235 bench-01-tokens/op/s      83722 bench-02-tof-ns          749148 bench-03-stddev-ns   101838680 B/op   3336161 allocs/op
    BenchmarkSequence-8            1        5000809941 ns/op             39442 bench-01-tokens/op/s      17637 bench-02-tof-ns           41809 bench-03-stddev-ns   102316760 B/op   3354054 allocs/op
    BenchmarkSequence-8            1        5000820632 ns/op             40055 bench-01-tokens/op/s      17572 bench-02-tof-ns           41938 bench-03-stddev-ns   103735416 B/op   3405978 allocs/op
    BenchmarkSequence-8            1        5000895439 ns/op             38734 bench-01-tokens/op/s      21606 bench-02-tof-ns           94477 bench-03-stddev-ns   100626560 B/op   3293691 allocs/op
    BenchmarkSequence-8            1        5000809052 ns/op             38585 bench-01-tokens/op/s      19815 bench-02-tof-ns           90039 bench-03-stddev-ns   100275320 B/op   3280962 allocs/op
    BenchmarkSequence-8            1        5000781796 ns/op             38089 bench-01-tokens/op/s      19170 bench-02-tof-ns           54319 bench-03-stddev-ns   99130840 B/op    3238921 allocs/op
    BenchmarkSequence-8            1        5000814104 ns/op             40189 bench-01-tokens/op/s      21419 bench-02-tof-ns          138923 bench-03-stddev-ns   104082232 B/op   3417544 allocs/op
    BenchmarkSequence-8            1        5000795569 ns/op             38516 bench-01-tokens/op/s      18647 bench-02-tof-ns           49049 bench-03-stddev-ns   100112568 B/op   3275088 allocs/op
    BenchmarkSequence-8            1        5000815765 ns/op             39433 bench-01-tokens/op/s      17260 bench-02-tof-ns           34661 bench-03-stddev-ns   102269240 B/op   3352992 allocs/op
    BenchmarkSequence-8            1        5000761623 ns/op             38565 bench-01-tokens/op/s      26883 bench-02-tof-ns          260246 bench-03-stddev-ns   100239912 B/op   3279302 allocs/op
    BenchmarkSequence-8            1        5000778284 ns/op             40565 bench-01-tokens/op/s      19964 bench-02-tof-ns           66057 bench-03-stddev-ns   104942728 B/op   3449264 allocs/op
    BenchmarkSequence-8            1        5000852462 ns/op             39812 bench-01-tokens/op/s      16593 bench-02-tof-ns           23011 bench-03-stddev-ns   103166664 B/op   3385346 allocs/op
    BenchmarkSequence-8            1        5000716961 ns/op             39840 bench-01-tokens/op/s      17739 bench-02-tof-ns           49892 bench-03-stddev-ns   103237080 B/op   3387702 allocs/op
    PASS
    ok      github.com/go-daq/tdaq/xdaq     150.070s
    
    $> benchstat ./ref.txt
    name        time/op
    Sequence-8            5.00s ± 0%
    
    name        bench-01-tokens/op/s
    Sequence-8            39.2k ± 5%
    
    name        bench-02-tof-ns
    Sequence-8            18.2k ±18%
    
    name        bench-03-stddev-ns
    Sequence-8           54.3k ±174%
    
    name        alloc/op
    Sequence-8            102MB ± 4%
    
    name        allocs/op
    Sequence-8            3.34M ± 5%

```